### PR TITLE
Define `toJSON` as writable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ Object.defineProperty(Error.prototype, 'toJSON', {
 
         return alt;
     },
-    configurable: true
+    configurable: true,
+    writable: true
 });


### PR DESCRIPTION
This should resolve the original incompatibility with error creation in MongoDB's native driver (mongodb/node-mongodb-native#1293).
