### PR TITLE
Use only enumerable properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-if (!('toJSON' in Error.prototype))
+if ('toJSON' in Error.prototype) {
+  return;
+}
+
 Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};
 
-        Object.getOwnPropertyNames(this).forEach(function (key) {
+        Object.keys(this).forEach(function (key) {
             alt[key] = this[key];
         }, this);
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+if (!('toJSON' in Error.prototype))
 Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};


### PR DESCRIPTION
This pull-request only show enumerable properties instead of all the ones that could be attached to the `Error` object. This only don't show not vissible properties but also prevent crashes when using it to serialize Node.js `HTTPError` errors, that include a non-enumerable reference to the `Response` object that has circular references, that has been the main reason to do this fix. In the future an explicit check for circular references could be added if needed, but I don't think it would be the case...