### PR TITLE
Use `fclone` to do serialization and prevent circular references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-if (!('toJSON' in Error.prototype))
+if ('toJSON' in Error.prototype) {
+  return;
+}
+
 Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};
 
-        Object.getOwnPropertyNames(this).forEach(function (key) {
+        Object.keys(this).forEach(function (key) {
             alt[key] = this[key];
         }, this);
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+if (!('toJSON' in Error.prototype))
 Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
         var alt = {};

--- a/index.js
+++ b/index.js
@@ -1,16 +1,13 @@
+const fclone = require('fclone');
+
+
 if ('toJSON' in Error.prototype) {
   return;
 }
 
 Object.defineProperty(Error.prototype, 'toJSON', {
     value: function () {
-        var alt = {};
-
-        Object.keys(this).forEach(function (key) {
-            alt[key] = this[key];
-        }, this);
-
-        return alt;
+        return fclone(this);
     },
     configurable: true,
     writable: true

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/AVVS/error-tojson/issues"
   },
-  "homepage": "https://github.com/AVVS/error-tojson"
+  "homepage": "https://github.com/AVVS/error-tojson",
+  "dependencies": {
+    "fclone": "^1.0.11"
+  }
 }


### PR DESCRIPTION
Using solution at https://github.com/AVVS/error-tojson/pull/4 found the problem of `Error` objects `name` and  `stack` fields (and for native errors `message` fields too) were not being included because they are non-enumerable, leading to native errors with an empty objects. Due to this, I've taken the path to prevent circular references and decided to use the https://www.npmjs.com/package/fclone module, since doesn't have any dependency and seems to have a good usage popularity. I can confirm that this works as expected, showing the missing fields in `Error` objects (code has an explicit check for them), and circular object references are replaced by a `[Circular]` string.

I've done this in a new pull-request since previous one is hosted on my company Github organization and I don't have write access to it anymore.